### PR TITLE
Added typescript, tsx and jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,38 @@
   ],
   "contributes": {
     "snippets": [
-      {
-        "language": "javascript",
-        "path": "./snippets/ava.json"
-      },
-      {
-        "language": "javascript",
-        "path": "./snippets/assertions.json"
-      }
+    	{
+    		"language": "javascript",
+    		"path": "./snippets/ava.json"
+    	},
+    	{
+    		"language": "javascript",
+    		"path": "./snippets/assertions.json"
+    	},
+    	{
+    		"language": "typescript",
+    		"path": "./snippets/ava.json"
+    	},
+    	{
+    		"language": "typescript",
+    		"path": "./snippets/assertions.json"
+    	},
+    	{
+    		"language": "javascriptreact",
+    		"path": "./snippets/ava.json"
+    	},
+    	{
+    		"language": "javascriptreact",
+    		"path": "./snippets/assertions.json"
+    	},
+    	{
+    		"language": "typescriptreact",
+    		"path": "./snippets/ava.json"
+    	},
+    	{
+    		"language": "typescriptreact",
+    		"path": "./snippets/assertions.json"
+    	}
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,38 +20,38 @@
   ],
   "contributes": {
     "snippets": [
-    	{
-    		"language": "javascript",
-    		"path": "./snippets/ava.json"
-    	},
-    	{
-    		"language": "javascript",
-    		"path": "./snippets/assertions.json"
-    	},
-    	{
-    		"language": "typescript",
-    		"path": "./snippets/ava.json"
-    	},
-    	{
-    		"language": "typescript",
-    		"path": "./snippets/assertions.json"
-    	},
-    	{
-    		"language": "javascriptreact",
-    		"path": "./snippets/ava.json"
-    	},
-    	{
-    		"language": "javascriptreact",
-    		"path": "./snippets/assertions.json"
-    	},
-    	{
-    		"language": "typescriptreact",
-    		"path": "./snippets/ava.json"
-    	},
-    	{
-    		"language": "typescriptreact",
-    		"path": "./snippets/assertions.json"
-    	}
+      {
+        "language": "javascript",
+        "path": "./snippets/ava.json"
+      },
+      {
+        "language": "javascript",
+        "path": "./snippets/assertions.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets/ava.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets/assertions.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/ava.json"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/assertions.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/ava.json"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/assertions.json"
+      }
     ]
   }
 }

--- a/snippets/ava.json
+++ b/snippets/ava.json
@@ -80,7 +80,7 @@
 		"body": [
 			"test.failing('${1:title}', t => {",
 			"\t$2",
-			"}"
+			"});"
 		],
 		"description": "Test - Failing"
 	},


### PR DESCRIPTION
This is a fix requested in https://github.com/SamVerschueren/vscode-ava/pull/5
> Sorry for the super mega delay with this, i totally forgot and deleted the fork some months ago

changes:
- Added language support for `typescript`, `tsx` and `jsx`.
- Fixed closing bracket on `test.failing` snippet